### PR TITLE
feature/fargate-spot template の cfn_templates に depends on を追加

### DIFF
--- a/fargate_spot/go/cfn_templates/04_managed_task.yml
+++ b/fargate_spot/go/cfn_templates/04_managed_task.yml
@@ -130,6 +130,7 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: ecs
           Essential: true
+    DependsOn: LogGroup
 
   # ------------------------------------------------------------#
   # ECS Service
@@ -154,6 +155,7 @@ Resources:
             - !Ref Subnet1
             - !Ref Subnet2
             - !Ref Subnet3
+    DependsOn: TaskDefinition
 
   # ------------------------------------------------------------#
   #  Auto Scaling Service
@@ -181,6 +183,7 @@ Resources:
                   - ecs:DescribeServices
                   - ecs:UpdateService
                 Resource: '*'
+    DependsOn: Service
 
   ServiceScalingTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget


### PR DESCRIPTION
# Overview

feature/fargate-spot template の cfn_templates に depends on を追加

# How

- cfn_templates ファイルに depends on セクションを追加
    - log group -> task definition -> ecs service -> auto scaling 設定の順でデプロイされるように
